### PR TITLE
Add flexible date-range analysis

### DIFF
--- a/DateRangeFilter.js
+++ b/DateRangeFilter.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026
+ *
+ * Date-only helpers used to select ResMed BRP files before their large EDF
+ * payloads are read. Kept independent from the UI so the selection rules can
+ * be tested without a browser.
+ */
+(function (root, factory) {
+    const api = factory();
+
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+
+    root.GlasgowFileSelection = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    function compactDateToISO(value) {
+        if (typeof value !== 'string' || !/^\d{8}$/.test(value)) return null;
+
+        const year = Number(value.slice(0, 4));
+        const month = Number(value.slice(4, 6));
+        const day = Number(value.slice(6, 8));
+        const candidate = new Date(Date.UTC(year, month - 1, day));
+
+        if (candidate.getUTCFullYear() !== year ||
+            candidate.getUTCMonth() !== month - 1 ||
+            candidate.getUTCDate() !== day) {
+            return null;
+        }
+
+        return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+    }
+
+    function isISODate(value) {
+        if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+        return compactDateToISO(value.replace(/-/g, '')) === value;
+    }
+
+    function addDays(date, amount) {
+        if (!isISODate(date)) return null;
+
+        const [year, month, day] = date.split('-').map(Number);
+        const result = new Date(Date.UTC(year, month - 1, day + amount));
+        return [
+            result.getUTCFullYear(),
+            String(result.getUTCMonth() + 1).padStart(2, '0'),
+            String(result.getUTCDate()).padStart(2, '0')
+        ].join('-');
+    }
+
+    function getRelativePath(file) {
+        return String(
+            (file && (file.webkitRelativePath || file._relativePath || file.relativePath)) || ''
+        ).replace(/\\/g, '/');
+    }
+
+    function getFolderNightDate(file) {
+        const path = getRelativePath(file);
+        if (!path) return null;
+
+        const segments = path.split('/').filter(Boolean);
+        const directorySegments = segments.slice(0, -1);
+
+        for (const segment of directorySegments) {
+            const date = compactDateToISO(segment);
+            if (date) return date;
+        }
+
+        // Also support the DATALOG/YYYY/MMDD layout used by some backups.
+        for (let index = 0; index < directorySegments.length - 1; index++) {
+            if (/^\d{4}$/.test(directorySegments[index]) && /^\d{4}$/.test(directorySegments[index + 1])) {
+                const date = compactDateToISO(directorySegments[index] + directorySegments[index + 1]);
+                if (date) return date;
+            }
+        }
+
+        return null;
+    }
+
+    function getFileSleepNightDate(file) {
+        const folderDate = getFolderNightDate(file);
+        if (folderDate) return folderDate;
+
+        const fileName = String((file && file.name) || '');
+        const match = fileName.match(/(\d{8})_(\d{6})_BRP\.edf$/i);
+        if (!match) return null;
+
+        const sessionDate = compactDateToISO(match[1]);
+        if (!sessionDate) return null;
+
+        const hour = Number(match[2].slice(0, 2));
+        if (hour > 23) return null;
+
+        // Match the analyzer's existing sleep-night rule for individual files:
+        // sessions before noon belong to the previous night.
+        return hour < 12 ? addDays(sessionDate, -1) : sessionDate;
+    }
+
+    function getNightCoverage(files) {
+        const dates = [];
+        const undatedFiles = [];
+
+        (files || []).forEach(file => {
+            const date = getFileSleepNightDate(file);
+            if (date) {
+                dates.push(date);
+            } else {
+                undatedFiles.push(file);
+            }
+        });
+
+        const uniqueDates = [...new Set(dates)].sort();
+        return {
+            dates: uniqueDates,
+            firstDate: uniqueDates.length ? uniqueDates[0] : null,
+            lastDate: uniqueDates.length ? uniqueDates[uniqueDates.length - 1] : null,
+            undatedFiles
+        };
+    }
+
+    function selectFilesByDateRange(files, startDate, endDate) {
+        if (!isISODate(startDate) || !isISODate(endDate)) {
+            throw new Error('Choose a valid start and end date.');
+        }
+        if (startDate > endDate) {
+            throw new Error('The start date must be on or before the end date.');
+        }
+
+        const includedFiles = [];
+        const outsideRangeFiles = [];
+        const undatedFiles = [];
+
+        (files || []).forEach(file => {
+            const date = getFileSleepNightDate(file);
+            if (!date) {
+                undatedFiles.push(file);
+            } else if (date >= startDate && date <= endDate) {
+                includedFiles.push(file);
+            } else {
+                outsideRangeFiles.push(file);
+            }
+        });
+
+        return { includedFiles, outsideRangeFiles, undatedFiles };
+    }
+
+    return {
+        addDays,
+        compactDateToISO,
+        getFileSleepNightDate,
+        getFolderNightDate,
+        getNightCoverage,
+        isISODate,
+        selectFilesByDateRange
+    };
+}));

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A comprehensive tool for analyzing multiple nights of ResMed PAP data to calcula
 ## Features
 
 - **Multi-Night Analysis**: Process multiple EDF files from different nights automatically
+- **Pre-Analysis Date Range**: Analyze only selected sleep nights from a full SD card to reduce processing time
 - **Complete Machine Analysis**: Extract machine type, IPAP, EPAP, pressure support, and PAP mode
 - **Weighted Averages**: Calculate proper weighted averages when multiple sessions exist per night
 - **Pressure Settings**: Analyze IPAP, EPAP, and pressure support trends alongside Glasgow Index
@@ -37,10 +38,15 @@ The tool analyzes 9 key components of flow limitations:
    - `multi_night_analyzer.html`
    - `EDFFile.js`
    - `FlowLimits.js`
+   - `DateRangeFilter.js`
 
 2. Open `multi_night_analyzer.html` in a modern web browser
 
-3. **For complete analysis**: Upload your entire ResMed SD card folder (recommended)
+3. Select your ResMed SD card folder or individual BRP files. The app scans the filenames and shows the available sleep-night span without reading the large BRP contents.
+
+4. Choose **All available nights**, **Last 30 days**, **Last 90 days**, or **Custom date range**, then click **Analyze**.
+
+5. **For complete analysis**: Upload your entire ResMed SD card folder (recommended)
    - **Includes**: Machine type, IPAP, EPAP, pressure support, PAP mode extraction
    - **Files analyzed**: DATALOG/*.edf, STR.edf, Identification.tgt, SETTINGS/*
    
@@ -93,13 +99,16 @@ Or in OSCAR backup directories:
 
 ### Web Interface Usage
 
-1. **File Selection**: 
-   - **Recommended**: Click "Choose Files" and select your entire SD card folder for complete analysis
-   - **Alternative**: Upload individual BRP.edf files for Glasgow Index analysis only
-   - The tool will automatically detect and process relevant files
+1. **File Selection**:
+   - **Recommended**: Click **Choose SD card** and select the card's root folder for complete analysis
+   - **Alternative**: Click **Choose BRP files** for Glasgow Index analysis only
+   - You can also drag and drop an SD card folder or individual files
+   - The tool detects the available sleep nights before analysis starts
 
-2. **Processing**: 
-   - Files are processed automatically after selection
+2. **Processing**:
+   - Choose **All available nights**, **Last 30 days**, **Last 90 days**, or **Custom date range** after selecting data
+   - The Analyze button shows how many nights will be processed
+   - Date-range selection happens before BRP file contents are read, so out-of-range breathing files do not consume analysis time
    - Machine identification and pressure settings are extracted first
    - Progress is shown with a progress bar and status updates
 

--- a/multi_night_analyzer.html
+++ b/multi_night_analyzer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-GB">
 <head>
+<meta charset="UTF-8">
     <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-0HCJ48VPWL"></script>
 <script>
@@ -18,6 +19,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
 <script src="EDFFile.js"></script>
 <script src="FlowLimits.js"></script>
+<script src="DateRangeFilter.js"></script>
 
 <style>
     body {
@@ -180,6 +182,110 @@
     .pill--privacy { border-color: #d1e7dd; background: #f3fff6; }
     .pill--source { border-color: #ffe69c; background: #fff9e6; }
     .ack-line { margin-top: 8px; font-size: 12px; color: #666; }
+
+    .analysis-scope {
+        display: none;
+        margin: 16px 0 20px;
+        padding: 16px;
+        border: 1px solid #d7e3f1;
+        border-radius: 8px;
+        background: #f5f9ff;
+    }
+    .analysis-scope h4 { margin: 0 0 10px; color: #234; }
+    .upload-picker {
+        padding: 24px 18px;
+        border: 2px dashed #9cb9d6;
+        border-radius: 8px;
+        background: #fbfdff;
+        text-align: center;
+    }
+    .upload-picker h4 { margin: 0 0 6px; color: #234; }
+    .upload-picker p { margin: 5px 0 16px; color: #667; font-size: 14px; }
+    .upload-actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 10px;
+    }
+    .file-input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+    .upload-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 9px 15px;
+        border: 1px solid #007bff;
+        border-radius: 5px;
+        background: #007bff;
+        color: white;
+        cursor: pointer;
+        font-weight: 600;
+    }
+    .upload-button--secondary { background: white; color: #315b80; border-color: #9cb9d6; }
+    .upload-note { margin-top: 12px; color: #667; font-size: 12px; }
+    .selection-summary {
+        margin-bottom: 14px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid #d7e3f1;
+        color: #345;
+        font-weight: 600;
+        white-space: pre-line;
+    }
+    .analysis-controls {
+        display: flex;
+        align-items: end;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+    .analysis-preset-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 190px;
+        color: #445;
+        font-size: 13px;
+    }
+    .analysis-preset-field select { padding: 8px; }
+    .analysis-date-block {
+        display: none;
+        align-items: end;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+    .analysis-date-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 13px;
+        color: #445;
+    }
+    .analysis-date-field input { padding: 7px; }
+    .analyze-button {
+        min-height: 36px;
+        padding: 8px 18px;
+        border: 0;
+        border-radius: 4px;
+        background: #007bff;
+        color: white;
+        cursor: pointer;
+        font-weight: 600;
+    }
+    .analyze-button:disabled { background: #9ab9d8; cursor: not-allowed; }
+    .analysis-range-hint { margin-top: 9px; font-size: 12px; color: #566; }
+
+    @media (max-width: 720px) {
+        .analysis-controls, .analysis-date-block { align-items: stretch; flex-direction: column; }
+        .analysis-preset-field, .analysis-date-field, .analyze-button { width: 100%; box-sizing: border-box; }
+    }
 </style>
 
 </head>
@@ -198,37 +304,49 @@
     </div>
     
           <div class="upload-section" id="uploadSection">
-          <h3>Upload Entire SD Card Data for complete analysis</h3>
-          <!-- <p><strong>For complete analysis including pressure settings, machine type, and all Glasgow Index data:</strong></p> -->
-          
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin: 20px 0;">
-              <div style="text-align: center; padding: 20px; border: 2px solid #007bff; border-radius: 8px; background: #f8f9ff;">
-                  <h4 style="margin-top: 0; color: #007bff;">📁 Upload Entire SD Card</h4>
-                  <p style="font-size: 14px; color: #666; margin-bottom: 15px;"><strong>Recommended:</strong> Select your entire ResMed SD card root folder</p>
-                  <input type="file" id="folderInput" webkitdirectory multiple style="margin: 10px 0;">
-                  <div style="font-size: 12px; color: #333; margin-top: 10px; font-weight: bold;">
-                      <!-- ✅ Includes: DATALOG, STR.edf, Identification.tgt, SETTINGS -->
-                  </div>
-                  <div style="font-size: 11px; color: #666; margin-top: 5px;">
-                      <!-- Extracts: Machine Type, IPAP, EPAP, Pressure Support, PAP Mode -->
-                  </div>
+          <h3>Select your ResMed data</h3>
+          <div class="upload-picker">
+              <h4>Drop an SD card folder or BRP files here</h4>
+              <p>Or choose the source that is easiest for you:</p>
+              <div class="upload-actions">
+                  <label class="upload-button" for="folderInput">📁 Choose SD card</label>
+                  <input class="file-input" type="file" id="folderInput" webkitdirectory multiple>
+                  <label class="upload-button upload-button--secondary" for="fileInput">📄 Choose BRP files</label>
+                  <input class="file-input" type="file" name="inputfiles" id="fileInput" multiple accept=".edf">
               </div>
-              
-              <div style="text-align: center; padding: 20px; border: 2px dashed #ffc107; border-radius: 8px; background: #fffbf0;">
-                  <h4 style="margin-top: 0; color: #856404;">📄 Or Upload Individual Files</h4>
-                  <p style="font-size: 14px; color: #666; margin-bottom: 15px;">Helpful to review a single night or an OSCAR Backup</p>
-                  <input type="file" name="inputfiles" id="fileInput" multiple accept=".edf" style="margin: 10px 0;">
-                  <div style="font-size: 12px; color: #856404; margin-top: 10px; font-weight: bold;">
-                      ⚠️ Limited: Glasgow Index only
-                  </div>
-                  <div style="font-size: 11px; color: #666; margin-top: 5px;">
-                      <!-- Missing: Pressure data, machine settings -->
-                  </div>
-              </div>
+              <div class="upload-note">An SD card includes machine settings. Individual BRP files provide Glasgow Index analysis only.</div>
           </div>
-          
-          
-          <div class="file-count" id="fileCount">No files selected</div>
+
+          <div class="analysis-scope" id="analysisScope">
+              <h4>Ready to analyze</h4>
+              <div class="selection-summary" id="fileCount"></div>
+              <div class="analysis-controls">
+                  <label class="analysis-preset-field" for="analysisRangePreset">
+                      Analyze
+                      <select id="analysisRangePreset" onchange="onAnalysisRangePresetChange()">
+                          <option value="all">All available nights</option>
+                          <option value="30">Last 30 days</option>
+                          <option value="90">Last 90 days</option>
+                          <option value="custom">Custom date range…</option>
+                      </select>
+                  </label>
+                  <div class="analysis-date-block" id="analysisDateBlock">
+                      <label class="analysis-date-field" for="analysisStartDate">
+                          First sleep night
+                          <input type="date" id="analysisStartDate" onchange="syncAnalysisDateLimits()">
+                      </label>
+                      <label class="analysis-date-field" for="analysisEndDate">
+                          Last sleep night
+                          <input type="date" id="analysisEndDate" onchange="syncAnalysisDateLimits()">
+                      </label>
+                  </div>
+                  <button type="button" class="analyze-button" id="analyzeSelectionButton" onclick="analyzePendingSelection()" disabled>
+                      Analyze
+                  </button>
+              </div>
+              <div class="analysis-range-hint" id="analysisRangeHint"></div>
+          </div>
+
           <div class="progress-bar" id="progressBar" style="display: none;">
               <div class="progress-fill" id="progressFill"></div>
           </div>
@@ -380,8 +498,17 @@
 <!-- Release Notes (collapsed by default) -->
 <div class="container" style="margin-top: 16px;">
     <details>
-        <summary style="cursor:pointer; font-weight:600;">Release Notes — Updated: <span id="releaseNotesDate">2025-12-10</span></summary>
+        <summary style="cursor:pointer; font-weight:600;">Release Notes — Updated: <span id="releaseNotesDate">2026-08-12</span></summary>
         <div style="margin-top:10px; font-size: 14px; color: #222; line-height: 1.6;">
+            <div style="background:#f8f9fa; border:1px solid #e9ecef; border-radius:8px; padding:12px; margin-bottom:12px;">
+                <div style="font-weight:bold; margin-bottom:6px;">2026-08-12</div>
+                <ul style="margin:0 0 8px 18px;">
+                    <li><strong>Simpler analysis flow:</strong> Select data first, then choose All, Last 30 days, Last 90 days, or a custom date range</li>
+                    <li>The app shows the detected night count and date span before analysis starts</li>
+                    <li>Out-of-range BRP file contents are not read, reducing analysis time</li>
+                    <li>Large dragged folders now read every browser directory batch instead of stopping after the first batch</li>
+                </ul>
+            </div>
             <div style="background:#f8f9fa; border:1px solid #e9ecef; border-radius:8px; padding:12px; margin-bottom:12px;">
                 <div style="font-weight:bold; margin-bottom:6px;">2025-12-10</div>
                 <ul style="margin:0 0 8px 18px;">
@@ -410,6 +537,8 @@
 let nightlyResults = [];
 let trendsChart = null;
 let componentsChart = null;
+let pendingFileSelection = null;
+let analysisInProgress = false;
 
 // File handling
 document.getElementById('fileInput').addEventListener('change', function (event) {
@@ -458,7 +587,7 @@ uploadSection.addEventListener('drop', function(e) {
         }
         
         Promise.all(promises).then(results => {
-            const allFiles = results.flat().filter(file => file.name.endsWith('.edf'));
+            const allFiles = results.flat();
             if (allFiles.length > 0) {
                 handleFiles(allFiles);
             } else {
@@ -474,31 +603,68 @@ uploadSection.addEventListener('drop', function(e) {
     }
 });
 
-// Process directory entries recursively
+// DirectoryReader returns entries in batches (often no more than 100), so keep
+// reading until the browser reports that the directory is exhausted.
+function readAllDirectoryEntries(directoryReader) {
+    return new Promise((resolve, reject) => {
+        const entries = [];
+
+        function readNextBatch() {
+            directoryReader.readEntries(batch => {
+                if (batch.length === 0) {
+                    resolve(entries);
+                    return;
+                }
+                entries.push(...batch);
+                readNextBatch();
+            }, reject);
+        }
+
+        readNextBatch();
+    });
+}
+
+// Process directory entries recursively and retain their path. File objects
+// created by drag-and-drop do not expose webkitRelativePath themselves.
 function processEntry(entry) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         if (entry.isFile) {
-            entry.file(resolve);
+            entry.file(file => {
+                try {
+                    Object.defineProperty(file, '_relativePath', {
+                        value: entry.fullPath || '',
+                        configurable: true
+                    });
+                } catch (error) {
+                    file._relativePath = entry.fullPath || '';
+                }
+                resolve(file);
+            }, reject);
         } else if (entry.isDirectory) {
             const dirReader = entry.createReader();
-            dirReader.readEntries((entries) => {
-                const promises = entries.map(processEntry);
-                Promise.all(promises).then(results => {
-                    resolve(results.flat());
-                });
-            });
+            readAllDirectoryEntries(dirReader)
+                .then(entries => Promise.all(entries.map(processEntry)))
+                .then(results => resolve(results.flat()))
+                .catch(reject);
+        } else {
+            resolve([]);
         }
     });
 }
 
 function handleFiles(files) {
-    const brpFiles = files.filter(file => file.name.includes('_BRP.edf'));
+    if (analysisInProgress) {
+        alert('Please wait for the current analysis to finish before selecting new data.');
+        return;
+    }
+
+    const brpFiles = files.filter(file => /_BRP\.edf$/i.test(file.name));
     const identificationFiles = files.filter(file => 
-        file.name === 'Identification.tgt' || 
-        file.name === 'Identification.json'
+        file.name.toLowerCase() === 'identification.tgt' ||
+        file.name.toLowerCase() === 'identification.json'
     );
-    const strFiles = files.filter(file => file.name === 'STR.edf');
-    const allEdfFiles = files.filter(file => file.name.endsWith('.edf'));
+    const strFiles = files.filter(file => file.name.toLowerCase() === 'str.edf');
+    const allEdfFiles = files.filter(file => file.name.toLowerCase().endsWith('.edf'));
     
     if (brpFiles.length === 0) {
         if (allEdfFiles.length > 0) {
@@ -515,64 +681,226 @@ function handleFiles(files) {
         }
         return;
     }
-    
-    // Extract folder-based sleep night date from webkitRelativePath if available
-    // Path format: DATALOG/20250724/20250724_232010_BRP.edf
-    // The folder name (20250724) represents the sleep night, even if file timestamps cross midnight
-    function extractFolderDate(file) {
-        if (file.webkitRelativePath) {
-            // Match folder name in format YYYYMMDD from path like "DATALOG/20250724/filename.edf"
-            const pathMatch = file.webkitRelativePath.match(/\/(\d{8})\//);
-            if (pathMatch) {
-                return pathMatch[1];
-            }
-        }
-        return null;
+
+    if (!window.GlasgowFileSelection) {
+        alert('The date selection helper could not be loaded. Please keep DateRangeFilter.js in the same folder as this page.');
+        return;
     }
-    
-    // Group files by night to show better summary (prefer folder date over filename date)
-    const nightGroups = {};
+
+    const coverage = GlasgowFileSelection.getNightCoverage(brpFiles);
+
+    // Preserve the authoritative DATALOG folder date for grouping after each
+    // selected EDF has been parsed.
     brpFiles.forEach(file => {
-        // Try folder date first, fall back to filename date
-        let date = extractFolderDate(file);
-        if (!date) {
-            const match = file.name.match(/(\d{8})_/);
-            if (match) date = match[1];
-        }
-        if (date) {
-            if (!nightGroups[date]) nightGroups[date] = 0;
-            nightGroups[date]++;
-        }
+        const folderDate = GlasgowFileSelection.getFolderNightDate(file);
+        file._folderDate = folderDate ? folderDate.replace(/-/g, '') : null;
     });
-    
-    const nightCount = Object.keys(nightGroups).length;
-    const sessionCount = brpFiles.length;
-    
-    let countText = `Found ${sessionCount} breathing data files from ${nightCount} night${nightCount !== 1 ? 's' : ''}`;
-    
-    if (allEdfFiles.length > brpFiles.length) {
-        const otherCount = allEdfFiles.length - brpFiles.length;
-        countText += ` (${otherCount} other EDF files ignored)`;
+
+    pendingFileSelection = {
+        brpFiles,
+        identificationFiles,
+        strFiles,
+        allEdfFiles,
+        coverage
+    };
+
+    document.getElementById('resultsSection').style.display = 'none';
+    document.getElementById('analysisScope').style.display = 'block';
+    document.getElementById('analysisRangePreset').value = 'all';
+    configureAnalysisDateRange(coverage);
+    showFileSelectionSummary(brpFiles, allEdfFiles);
+    document.getElementById('processingStatus').textContent = '';
+    onAnalysisRangePresetChange();
+}
+
+function getAnalysisPreset() {
+    return document.getElementById('analysisRangePreset').value || 'all';
+}
+
+function configureAnalysisDateRange(coverage) {
+    const startInput = document.getElementById('analysisStartDate');
+    const endInput = document.getElementById('analysisEndDate');
+    const presetSelect = document.getElementById('analysisRangePreset');
+    const hasDatedNights = Boolean(coverage.firstDate && coverage.lastDate);
+
+    startInput.min = coverage.firstDate || '';
+    startInput.max = coverage.lastDate || '';
+    endInput.min = coverage.firstDate || '';
+    endInput.max = coverage.lastDate || '';
+    startInput.value = coverage.firstDate || '';
+    endInput.value = coverage.lastDate || '';
+
+    Array.from(presetSelect.options).forEach(option => {
+        if (option.value !== 'all') option.disabled = !hasDatedNights;
+    });
+}
+
+function onAnalysisRangePresetChange() {
+    const preset = getAnalysisPreset();
+    const dateBlock = document.getElementById('analysisDateBlock');
+    const startInput = document.getElementById('analysisStartDate');
+    const endInput = document.getElementById('analysisEndDate');
+    const coverage = pendingFileSelection?.coverage;
+
+    dateBlock.style.display = preset === 'custom' ? 'flex' : 'none';
+
+    if (coverage?.firstDate && coverage?.lastDate) {
+        if (preset === 'all') {
+            startInput.value = coverage.firstDate;
+            endInput.value = coverage.lastDate;
+        } else if (preset !== 'custom') {
+            const days = Number(preset);
+            const presetStart = GlasgowFileSelection.addDays(coverage.lastDate, -(days - 1));
+            startInput.value = presetStart > coverage.firstDate ? presetStart : coverage.firstDate;
+            endInput.value = coverage.lastDate;
+        }
     }
-    
-    // Show which nights were found
-    if (nightCount <= 10) {
-        const nightDates = Object.keys(nightGroups).sort().map(date => {
+
+    syncAnalysisDateLimits();
+}
+
+function syncAnalysisDateLimits() {
+    const startInput = document.getElementById('analysisStartDate');
+    const endInput = document.getElementById('analysisEndDate');
+    const analyzeButton = document.getElementById('analyzeSelectionButton');
+    const coverage = pendingFileSelection?.coverage;
+    const preset = getAnalysisPreset();
+
+    if (!window.GlasgowFileSelection) {
+        analyzeButton.disabled = true;
+        return;
+    }
+
+    startInput.max = endInput.value || coverage?.lastDate || '';
+    endInput.min = startInput.value || coverage?.firstDate || '';
+
+    if (!pendingFileSelection || analysisInProgress) {
+        analyzeButton.disabled = true;
+        return;
+    }
+
+    if (preset === 'all') {
+        const nightCount = coverage.dates.length;
+        analyzeButton.disabled = false;
+        analyzeButton.textContent = nightCount > 0
+            ? `Analyze all ${nightCount} night${nightCount === 1 ? '' : 's'}`
+            : `Analyze ${pendingFileSelection.brpFiles.length} breathing file${pendingFileSelection.brpFiles.length === 1 ? '' : 's'}`;
+        document.getElementById('analysisRangeHint').textContent =
+            `All ${pendingFileSelection.brpFiles.length} breathing files will be read.`;
+        return;
+    }
+
+    const datesAreValid = GlasgowFileSelection.isISODate(startInput.value) &&
+        GlasgowFileSelection.isISODate(endInput.value) &&
+        startInput.value <= endInput.value;
+    analyzeButton.disabled = !datesAreValid;
+
+    if (datesAreValid) {
+        const selection = GlasgowFileSelection.selectFilesByDateRange(
+            pendingFileSelection.brpFiles,
+            startInput.value,
+            endInput.value
+        );
+        const selectedCoverage = GlasgowFileSelection.getNightCoverage(selection.includedFiles);
+        const selectedNightCount = selectedCoverage.dates.length;
+        analyzeButton.disabled = selection.includedFiles.length === 0;
+        analyzeButton.textContent = selectedNightCount > 0
+            ? `Analyze ${selectedNightCount} night${selectedNightCount === 1 ? '' : 's'}`
+            : 'No nights in this range';
+        document.getElementById('analysisRangeHint').textContent =
+            `${selection.includedFiles.length} of ${pendingFileSelection.brpFiles.length} breathing files selected across ` +
+            `${selectedNightCount} sleep night${selectedNightCount === 1 ? '' : 's'} ` +
+            `(${startInput.value} through ${endInput.value}).` +
+            (selection.undatedFiles.length ? ` ${selection.undatedFiles.length} files with unknown dates will be skipped.` : '');
+    } else {
+        analyzeButton.textContent = 'Choose valid dates';
+        document.getElementById('analysisRangeHint').textContent = 'Choose a valid first and last sleep night.';
+    }
+}
+
+function showFileSelectionSummary(brpFiles, allEdfFiles, rangeSelection = null) {
+    const filesToSummarize = rangeSelection ? rangeSelection.includedFiles : brpFiles;
+    const coverage = GlasgowFileSelection.getNightCoverage(filesToSummarize);
+    const nightGroups = {};
+
+    filesToSummarize.forEach(file => {
+        const date = GlasgowFileSelection.getFileSleepNightDate(file);
+        if (date) nightGroups[date] = (nightGroups[date] || 0) + 1;
+    });
+
+    let countText = rangeSelection
+        ? `Analyzing ${filesToSummarize.length} of ${brpFiles.length} breathing data files from ${coverage.dates.length} night${coverage.dates.length === 1 ? '' : 's'}`
+        : `Found ${brpFiles.length} breathing data files from ${coverage.dates.length} night${coverage.dates.length === 1 ? '' : 's'}`;
+
+    if (allEdfFiles.length > brpFiles.length) {
+        countText += ` (${allEdfFiles.length - brpFiles.length} other EDF files detected)`;
+    }
+    if (rangeSelection?.outsideRangeFiles.length) {
+        countText += `; ${rangeSelection.outsideRangeFiles.length} breathing files outside the range will not be read`;
+    }
+    if (rangeSelection?.undatedFiles.length) {
+        countText += `; ${rangeSelection.undatedFiles.length} breathing files with unknown dates will not be read`;
+    } else if (!rangeSelection && coverage.undatedFiles.length) {
+        countText += `; ${coverage.undatedFiles.length} files have unknown sleep-night dates`;
+    }
+
+    if (coverage.dates.length > 0 && coverage.dates.length <= 10) {
+        const nightDates = coverage.dates.map(date => {
             const sessionCount = nightGroups[date];
-            const formattedDate = `${date.slice(0,4)}-${date.slice(4,6)}-${date.slice(6,8)}`;
-            return sessionCount > 1 ? `${formattedDate} (${sessionCount} sessions)` : formattedDate;
+            return sessionCount > 1 ? `${date} (${sessionCount} sessions)` : date;
         });
         countText += `\n\nNights: ${nightDates.join(', ')}`;
+    } else if (coverage.firstDate && coverage.lastDate) {
+        countText += `\n\nAvailable span: ${coverage.firstDate} through ${coverage.lastDate}`;
     }
-    
+
     document.getElementById('fileCount').textContent = countText;
-    
-    // Attach folder date to each file for use during processing
-    brpFiles.forEach(file => {
-        file._folderDate = extractFolderDate(file);
-    });
-    
-    processFiles(brpFiles, identificationFiles, strFiles);
+}
+
+async function analyzePendingSelection() {
+    if (!pendingFileSelection || analysisInProgress) return;
+
+    let brpFiles = pendingFileSelection.brpFiles;
+    let rangeSelection = null;
+
+    const preset = getAnalysisPreset();
+    if (preset !== 'all') {
+        const startDate = document.getElementById('analysisStartDate').value;
+        const endDate = document.getElementById('analysisEndDate').value;
+
+        try {
+            rangeSelection = GlasgowFileSelection.selectFilesByDateRange(brpFiles, startDate, endDate);
+        } catch (error) {
+            alert(error.message);
+            return;
+        }
+
+        brpFiles = rangeSelection.includedFiles;
+        if (brpFiles.length === 0) {
+            alert('No breathing files were found in that sleep-night date range. Choose a wider range and try again.');
+            return;
+        }
+    }
+
+    analysisInProgress = true;
+    setAnalysisControlsDisabled(true);
+
+    try {
+        await processFiles(brpFiles, pendingFileSelection.identificationFiles, pendingFileSelection.strFiles);
+    } finally {
+        analysisInProgress = false;
+        setAnalysisControlsDisabled(false);
+        syncAnalysisDateLimits();
+    }
+}
+
+function setAnalysisControlsDisabled(disabled) {
+    document.getElementById('analysisRangePreset').disabled = disabled;
+    document.getElementById('analysisStartDate').disabled = disabled;
+    document.getElementById('analysisEndDate').disabled = disabled;
+    document.getElementById('folderInput').disabled = disabled;
+    document.getElementById('fileInput').disabled = disabled;
+    document.getElementById('analyzeSelectionButton').disabled = disabled;
 }
 
 async function processFiles(brpFiles, identificationFiles = [], strFiles = []) {
@@ -645,7 +973,9 @@ function processFile(file, machineInfo = null, pressureSettings = null) {
             try {
                 const arrayBuffer = event.target.result;
                 // Pass folder date for accurate sleep night grouping
-                const result = analyzeFile(arrayBuffer, file.name, machineInfo, pressureSettings, file._folderDate);
+                const detectedFolderDate = window.GlasgowFileSelection?.getFolderNightDate(file);
+                const folderDate = file._folderDate || (detectedFolderDate ? detectedFolderDate.replace(/-/g, '') : null);
+                const result = analyzeFile(arrayBuffer, file.name, machineInfo, pressureSettings, folderDate);
                 resolve(result);
             } catch (error) {
                 console.error(`Error processing file ${file.name}:`, error);

--- a/tests/date_range_filter.test.js
+++ b/tests/date_range_filter.test.js
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const selection = require('../DateRangeFilter.js');
+
+function file(name, webkitRelativePath = '') {
+    return { name, webkitRelativePath };
+}
+
+test('uses the SD-card folder as the authoritative sleep-night date', () => {
+    const brp = file(
+        '20250820_021500_BRP.edf',
+        'RESMED/DATALOG/20250819/20250820_021500_BRP.edf'
+    );
+
+    assert.equal(selection.getFolderNightDate(brp), '2025-08-19');
+    assert.equal(selection.getFileSleepNightDate(brp), '2025-08-19');
+});
+
+test('supports DATALOG folders split into year and month-day', () => {
+    const brp = file(
+        '20250820_021500_BRP.edf',
+        'Backup/DATALOG/2025/0819/20250820_021500_BRP.edf'
+    );
+
+    assert.equal(selection.getFolderNightDate(brp), '2025-08-19');
+});
+
+test('applies the existing before-noon rule to individual files', () => {
+    assert.equal(
+        selection.getFileSleepNightDate(file('20260301_071500_BRP.edf')),
+        '2026-02-28'
+    );
+    assert.equal(
+        selection.getFileSleepNightDate(file('20260301_221500_BRP.edf')),
+        '2026-03-01'
+    );
+});
+
+test('calculates recent-day presets with UTC-safe date arithmetic', () => {
+    assert.equal(selection.addDays('2026-03-01', -29), '2026-01-31');
+    assert.equal(selection.addDays('2024-03-01', -1), '2024-02-29');
+});
+
+test('rejects impossible dates and invalid session hours', () => {
+    assert.equal(selection.getFileSleepNightDate(file('20260230_221500_BRP.edf')), null);
+    assert.equal(selection.getFileSleepNightDate(file('20260228_251500_BRP.edf')), null);
+});
+
+test('reports available nights and files that cannot be dated', () => {
+    const files = [
+        file('20250821_220000_BRP.edf'),
+        file('20250820_220000_BRP.edf'),
+        file('20250821_230000_BRP.edf'),
+        file('renamed_BRP.edf')
+    ];
+
+    assert.deepEqual(selection.getNightCoverage(files), {
+        dates: ['2025-08-20', '2025-08-21'],
+        firstDate: '2025-08-20',
+        lastDate: '2025-08-21',
+        undatedFiles: [files[3]]
+    });
+});
+
+test('selects an inclusive date range before processing', () => {
+    const files = [
+        file('20250819_220000_BRP.edf'),
+        file('20250820_220000_BRP.edf'),
+        file('20250821_220000_BRP.edf'),
+        file('renamed_BRP.edf')
+    ];
+
+    const result = selection.selectFilesByDateRange(files, '2025-08-20', '2025-08-21');
+
+    assert.deepEqual(result.includedFiles, [files[1], files[2]]);
+    assert.deepEqual(result.outsideRangeFiles, [files[0]]);
+    assert.deepEqual(result.undatedFiles, [files[3]]);
+});
+
+test('requires a complete, ordered date range', () => {
+    assert.throws(
+        () => selection.selectFilesByDateRange([], '', '2025-08-21'),
+        /valid start and end date/
+    );
+    assert.throws(
+        () => selection.selectFilesByDateRange([], '2025-08-22', '2025-08-21'),
+        /start date must be on or before the end date/
+    );
+});


### PR DESCRIPTION
## Summary

- replace the pre-upload mode choice with a simpler select-data-first workflow
- add All, Last 30 days, Last 90 days, and custom sleep-night ranges
- filter BRP sessions before file contents are read
- preserve SD-card folder dates and individual-file sleep-night fallback behavior
- read every browser directory batch for large dragged SD-card folders
- document the new workflow and add focused date-selection tests

## Why

The analyzer previously processed every selected BRP file before its chart-level date filter could be applied. Large SD cards therefore took unnecessary time, and the first date-range interaction required users to choose a mode before the available dates were known.

## User impact

Users now select their SD card or BRP files first, see the detected night count and date span, choose an analysis range, and start analysis with a button that shows how many nights will be processed. Files outside the chosen range are not read.

## Validation

- `node --test tests/date_range_filter.test.js` — 8 passing tests
- `node --check DateRangeFilter.js`
- parsed both inline HTML scripts successfully
- browser-tested All, Last 30 days, Last 90 days, and custom date-range flows
- confirmed a custom two-night range read only the two selected BRP fixtures
- `git diff --check`
